### PR TITLE
Run tests in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
       - run:
           name: Run npm test
-          command: node -e 'console.log(process.env.CNCSTR)'
+          command: npm run test
 
       - run:
           name: Print couchbase logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etops/ottoman",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "type": "git",
     "url": "http://github.com/etops/node-ottoman.git"
   },
-  "version": "1.0.8"
+  "version": "1.0.9"
 }


### PR DESCRIPTION
Fixes a copy-paste error preventing the tests from being run in the ci.
The tests were broken quite some time before the migration and the copy-paste error taking place, though :(